### PR TITLE
fixed error where setNeedsDisplay needs to be on the main queue along wi...

### DIFF
--- a/MDRadialProgress/MDRadialProgressView.m
+++ b/MDRadialProgress/MDRadialProgressView.m
@@ -88,14 +88,20 @@
 {
 	_progressCounter = progressCounter;
 	[self notifyProgressChange];
-	[self setNeedsDisplay];
+    
+    //setNeedsDisplay needs to be in the main queue to update the drawRect if the caller of this method is in a different queue
+	dispatch_async(dispatch_get_main_queue(), ^{
+        [self setNeedsDisplay];
+    });
 }
 
 - (void)setProgressTotal:(NSUInteger)progressTotal
 {
 	_progressTotal = progressTotal;
 	[self notifyProgressChange];
-	[self setNeedsDisplay];
+	dispatch_async(dispatch_get_main_queue(), ^{
+        [self setNeedsDisplay];
+    });
 }
 
 #pragma mark - Drawing

--- a/MDRadialProgress/ViewController.m
+++ b/MDRadialProgress/ViewController.m
@@ -58,6 +58,7 @@
     radialView.progressCounter = 4;
 	radialView.theme.sliceDividerHidden = YES;
     [scrollView addSubview:radialView];
+    
 //	Example 1 ========================================================================
 	
 	y += 80;
@@ -119,6 +120,16 @@
 	radialView2.label.hidden = YES;
 
 	[scrollView addSubview:radialView2];
+    
+    //demonstrates that progressCounter will fail if progressCounter is not in main queue
+    dispatch_queue_t metronomeQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+    dispatch_async(metronomeQueue, ^{
+        for (int i = 1; i < 6; i++) {
+            radialView2.progressCounter = i;
+            [NSThread sleepForTimeInterval:0.5];
+        }
+    });
+    
 //	Example 2 ========================================================================
 	
 	y += 130;


### PR DESCRIPTION
Hi,

Working with your api and found an issue with updating the progressCounter inside another block other than the main queue.  I have provided the fix and a example in your ViewController of the fix.  The issue is if someone is calling the progressCounter in a different thread, drawRect will not get called because it's on the main thread. See http://stackoverflow.com/questions/8313246/setneedsdisplay-not-working-inside-a-block for more details.
