### PR TITLE
Delete unnecessary condition and fix a bug if progressCounter = 0

### DIFF
--- a/MDRadialProgress/MDRadialProgressView.m
+++ b/MDRadialProgress/MDRadialProgressView.m
@@ -116,18 +116,17 @@
 	CGSize viewSize = self.bounds.size;
 	CGPoint center = CGPointMake(viewSize.width / 2, viewSize.height / 2);
 	
-	if (self.progressCounter > 0) {
-		// Draw the slices.
-		CGFloat radius = viewSize.width / 2 - self.internalPadding;
-		[self drawSlices:self.progressTotal
-			   completed:self.progressCounter
-				  radius:radius
-				  center:center
-			   inContext:contextRef];
-		
-		// Draw the slice separators.
-		[self drawSlicesSeparators:contextRef withViewSize:viewSize andCenter:center];
-	}
+	// Draw the slices.
+    CGFloat radius = viewSize.width / 2 - self.internalPadding;
+    [self drawSlices:self.progressTotal
+           completed:self.progressCounter
+              radius:radius
+              center:center
+           inContext:contextRef];
+    
+    // Draw the slice separators.
+    [self drawSlicesSeparators:contextRef withViewSize:viewSize andCenter:center];
+	
 	
     // Draw the center.
 	[self drawCenter:contextRef withViewSize:viewSize andCenter:center];


### PR DESCRIPTION
Hello Marco,

Congratulations, your control has evolved. :)

I corrected an unnecessary condition that causes a bug if the progressCounter property is equal to 0. First, if progressCounter is equal to 0, the condition "if (self.progressCounter > 0)" is equal to false which causes the radial to not be drawn. I delete the condition(property is an unsigned integer so self.progressCounter >= 0 is always true). I tested with your example project and this does not seem to bring regression.

A remark : Between line 205 and line 215. (in "self.progressCounter < self progressTotal" condition), it's not clear. Is you  launch an analyze, you will see that endAngle is never read. In addition, your startAngle variable is equal to originAngle variable in method CGContextAddArc so I think that the arc will not be drawn. Maybe I didn't understand this part of code.

Marc
