### PR TITLE
Added block to allow custom label text (instead of percentage only)

### DIFF
--- a/MDRadialProgress/MDRadialProgressView.h
+++ b/MDRadialProgress/MDRadialProgressView.h
@@ -37,4 +37,7 @@ static NSString *keyThickness = @"theme.thickness";
 // The label shown in the view's center.
 @property (strong, nonatomic) MDRadialProgressLabel *label;
 
+// The block that is used to update the label text when the progress changes.
+@property (nonatomic, copy) NSString *(^labelTextBlock)(MDRadialProgressView *progressView);
+
 @end

--- a/MDRadialProgress/MDRadialProgressView.m
+++ b/MDRadialProgress/MDRadialProgressView.m
@@ -275,10 +275,19 @@
 - (void)notifyProgressChange
 {
 	// Update the accessibilityValue and the progressSummaryView text.
-	float percentageCompleted = (100.0f / self.progressTotal) * self.progressCounter;
-	
-	self.accessibilityValue = [NSString stringWithFormat:@"%.2f", percentageCompleted];
-	self.label.text = [NSString stringWithFormat:@"%.0f", percentageCompleted];
+
+    NSString *text;
+
+    if (self.labelTextBlock) {
+        text = self.labelTextBlock(self);
+    }
+    else {
+        float percentageCompleted = (100.0f / self.progressTotal) * self.progressCounter;
+        text = [NSString stringWithFormat:@"%.0f", percentageCompleted];
+    }
+
+	self.accessibilityValue = text;
+	self.label.text = text;
 	
 	NSString *notificationText = [NSString stringWithFormat:@"%@ %@",
 								  NSLocalizedString(@"Progress changed to:", nil),


### PR DESCRIPTION
I wanted to be able to customize the text shown in the label without having to add an extra UILabel. If the block is set, it is used to get the text, otherwise the default text based on the progress is used.
