### PR TITLE
Fix label resizing problem

### DIFF
--- a/MDRadialProgress/MDRadialProgress/MDRadialProgressLabel.m
+++ b/MDRadialProgress/MDRadialProgress/MDRadialProgressLabel.m
@@ -85,7 +85,7 @@
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-	if ([keyPath isEqualToString:keyThickness]) {
+	if ([keyPath isEqualToString:keyThickness] || [keyPath isEqualToString:keyFrame]) {
 		MDRadialProgressView *view = (MDRadialProgressView *)object;
 		CGFloat offset = view.theme.thickness;
 		CGRect frame = view.frame;

--- a/MDRadialProgress/MDRadialProgress/MDRadialProgressView.h
+++ b/MDRadialProgress/MDRadialProgress/MDRadialProgressView.h
@@ -8,8 +8,8 @@
 #import <UIKit/UIKit.h>
 
 
-static NSString *keyThickness = @"theme.thickness";
-
+static NSString *keyThickness   = @"theme.thickness";
+static NSString *keyFrame       = @"frame";
 
 @class MDRadialProgressTheme;
 @class MDRadialProgressLabel;

--- a/MDRadialProgress/MDRadialProgress/MDRadialProgressView.m
+++ b/MDRadialProgress/MDRadialProgress/MDRadialProgressView.m
@@ -81,11 +81,13 @@
 	
 	// Register the progress label for changes in the thickness so that it can be repositioned.
 	[self addObserver:self.label forKeyPath:keyThickness options:NSKeyValueObservingOptionNew context:nil];
+    [self addObserver:self.label forKeyPath:keyFrame options:NSKeyValueObservingOptionNew context:nil];
 }
 
 - (void)dealloc
 {
     [self removeObserver:self.label forKeyPath:keyThickness];
+    [self removeObserver:self.label forKeyPath:keyFrame];
 }
 
 #pragma mark - Setters


### PR DESCRIPTION
Fixed a bug on MDRadialProgressLabel.
When MDRadialProgressView is resized, MDRadialProgressLabel isn't resizing, so text isn't right displayed.
