### PR TITLE
Added support for Auto Layout

### DIFF
--- a/MDRadialProgress/MDRadialProgress/MDRadialProgressView.m
+++ b/MDRadialProgress/MDRadialProgress/MDRadialProgressView.m
@@ -96,6 +96,11 @@
 	}
 }
 
+- (CGSize)intrinsicContentSize
+{
+    return self.frame.size;
+}
+
 - (void)dealloc
 {
 	for (NSString *observedKey in [self themePropertiesToObserve]) {


### PR DESCRIPTION
This pull request adds support for Apple's Auto Layout system by overriding `- (CGSize)intrinsicContentSize` on `MDRadialProgressView`.  This change allows a progress view to be correctly positioned by auto layout constraints.

Per Apple's [Auto Layout Guide](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/AutolayoutPG/ImplementingView/ImplementingView.html):

> If you implement a custom view class, you must provide enough information so that the Auto Layout system can make the correct calculations and satisfy the constraints. In particular, you should determine whether the view has an intrinsic size, and if so, implement intrinsicContentSize to return a suitable value

Since `MDRadialProgressView` has a natural size (the frame size used to construct it), it makes sense to implement this method, similar to how buttons and labels implement it.

> Leaf-level views, such as buttons, typically know more about what size they should be than does the code that is positioning them. This is communicated through the method `intrinsicContentSize`, which tells the layout system that there is some content it doesn’t natively understand in a view, and which provides to the layout system the intrinsic size of that content.
> 
> A typical example is a single-line text field. The layout system does not understand text—it must just be told that there’s something in the view, and that that something will require a certain amount of space in order not to clip the content. The layout system calls intrinsicContentSize, and sets up constraints that specify (1) that the opaque content should not be compressed or clipped and (2) that the view prefers to hug tightly to its content.

Merging this pull request would make it easier to support positioning an MDRadialProgressView on devices of different sizes without negatively impacting currently supported usage.
